### PR TITLE
Add batch scripts to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # perform LF normalization
 win-debloat.sh text eol=lf
+
+# batch scripts only support clrf
+# prevents conversion from Git/GitHub
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
Prevents batch scripts from being converted to other line endings by Git/GitHub. If LF line endings are used, batch labels completely break, which basically completely breaks scripts.