### PR TITLE
Disable Windows Error Reporting (WER)

### DIFF
--- a/bin/registry/7+.reg
+++ b/bin/registry/7+.reg
@@ -207,10 +207,18 @@ Windows Registry Editor Version 5.00
 
 ; disable hibernation
 
-[HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Power]
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Power]
 "HibernateEnabled"=dword:00000000
 
 ; disable fast startup
 
-[HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Power]
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Power]
 "HiberbootEnabled"=dword:00000000
+
+; disable windows error reporting
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting]
+"DoReport"=dword:00000000
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting]
+"Disabled"=dword:00000001


### PR DESCRIPTION
Currently Windows Error Reporting (WER) is not configured:

![Windows-Error-Reporting_enabled](https://github.com/amitxv/PC-Tuning/assets/101590573/cacec35c-7a0a-48cd-80c1-adf06f69c0f1)

It may send/report data about current device to Microsoft.

``Error Reporting is used to report information about a system or application that has failed or has stopped responding and is used to improve the quality of the product. ``

``Windows Error Reporting (WER) is a flexible event-based feedback infrastructure designed to gather information about the hardware and software problems that Windows can detect, report the information to Microsoft, and provide users with any available solutions.``

After using the registry keys:

![Windows-Error-Reporting_disabled](https://github.com/amitxv/PC-Tuning/assets/101590573/c8b462ce-3064-44ab-a8df-683dda2a93e9)

1) https://en.wikipedia.org/wiki/Windows_Error_Reporting#Privacy_concerns_and_use_by_the_NSA
2) https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.InternetCommunicationManagement::PCH_DoNotReport
3) https://www.tenforums.com/tutorials/107232-enable-disable-windows-error-reporting-windows-10-a.html
4) https://docs.microsoft.com/en-us/windows/win32/wer/windows-error-reporting