### PR TITLE
Removed/ Commented KsecPKG

### DIFF
--- a/bin/minimal-services.ini
+++ b/bin/minimal-services.ini
@@ -47,7 +47,6 @@ secdrv
 tcpipreg
 CLFS
 fvevol
-KSecPkg
 rdyboost
 storflt
 AsyncMac
@@ -134,7 +133,7 @@ luafv
 # msisadrv # Uncommenting breaks: Keyboard on mobile devices
 # Psched # Uncommenting breaks: QoS policies, may lead to delayed network initialization at boot if disabled
 # pcw # Uncommenting breaks: Stock Task Manager (use process explorer as an alternative)
-
+# KSecPkg # Uncommenting breaks: Ksecdd and causes alot of BSOD (like when uploading files)
 [rename_binaries]
 C:\Windows\System32\RuntimeBroker.exe
 C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy


### PR DESCRIPTION
KsecPKG Should never be disabled as it causes alot of issues, 
it will cause a BSOD whenever you try to upload files directly from upload buttons. 
"KMODE_EXCEPTION_NOT_HANDLED" with Ksecdd.sys.
So in this simple pull request i've just removed / commented KsecPKG to prevent most people from disabling it