### PR TITLE
Configure registry in order to uninstall MS Edge properly

### DIFF
--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -242,7 +242,7 @@ Open CMD and enter the commands below. The legacy version of Microsoft Edge will
 - Microsoft Edge
 
     ```bat
-    if exist "C:\Program Files (x86)\Microsoft\Edge\Application" (for /f "delims=" %a in ('where /r "C:\Program Files (x86)\Microsoft\Edge\Application" *setup.exe*') do ("%a" --uninstall --system-level --verbose-logging --force-uninstall))
+    > nul 2>&1 (reg delete "HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /v "NoRemove" /f & reg delete "HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientState\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}" /v "experiment_control_labels" /f & reg add "HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdateDev" /v "AllowUninstall" /t REG_DWORD /d "1" /f) & if exist "C:\Program Files (x86)\Microsoft\Edge\Application" (for /f "delims=" %a in ('where /r "C:\Program Files (x86)\Microsoft\Edge\Application" *setup.exe*') do ("%a" --uninstall --system-level --verbose-logging --force-uninstall))
     ```
 
 - OneDrive


### PR DESCRIPTION
## Description
On newer builds of Windows 10 and 11, the old method of uninstalling chromium edition of Microsoft Edge didn't work at all.
The workaround was to copy an older version of the setup.exe file from the older build of Windows. Hovewer, it would make instructions in the guide unclear and more complicated.

## Solution
Therefore, I tried to make more research and I have recently found a new workaround that seems to work fine on newer version of Edge Chromium:

```bat
rem Remove NoRemove from Microsoft Edge uninstall registry key
reg delete "HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /v "NoRemove" /f

rem Delete experiment_control_labels value if it exists
reg delete "HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\ClientState\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}" /v "experiment_control_labels" /f

rem Create EdgeUpdateDev key and add AllowUninstall value
reg add "HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdateDev" /v "AllowUninstall" /t REG_DWORD /d "1" /f
```

Because of this fix, Edge can be uninstalled successfully on each Windows version without any problems.

**Main source: https://gist.github.com/ave9858/c3451d9f452389ac7607c99d45edecc6**

## Note

Despite removing Edge in ``win-debloat.sh``, some shortcuts and registry stay untouched, thus this method is completely essential.