### PR TITLE
Remove unnecessary adnotation regarding Windows 11

### DIFF
--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -4,7 +4,7 @@
 
 - Windows Server will force you to enter a complex password which we will remove in a few steps later
 
-- If you are configuring Windows 11, press ``Shift+F10`` to open CMD and execute ``oobe\BypassNRO.cmd``. This will allow us to continue without an internet connection as demonstrated in the video examples below. This does not apply while installing Windows with USB
+- If you are configuring Windows 11, press ``Shift+F10`` to open CMD and execute ``oobe\BypassNRO.cmd``. This will allow us to continue without an internet connection as demonstrated in the video examples below. This does not apply when installing Windows with USB
 
 - See [media/oobe-windows7-example.mp4](https://raw.githubusercontent.com/amitxv/PC-Tuning/main/media/oobe-windows7-example.mp4)
 

--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -4,8 +4,6 @@
 
 - Windows Server will force you to enter a complex password which we will remove in a few steps later
 
-- If you are configuring Windows 11, press ``Shift+F10`` to open CMD and execute ``oobe\BypassNRO.cmd``. This will allow us to continue without an internet connection as demonstrated in the video examples below.
-
 - See [media/oobe-windows7-example.mp4](https://raw.githubusercontent.com/amitxv/PC-Tuning/main/media/oobe-windows7-example.mp4)
 
 - See [media/oobe-windows8-example.mp4](https://raw.githubusercontent.com/amitxv/PC-Tuning/main/media/oobe-windows8-example.mp4)

--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -4,6 +4,8 @@
 
 - Windows Server will force you to enter a complex password which we will remove in a few steps later
 
+- If you are configuring Windows 11, press ``Shift+F10`` to open CMD and execute ``oobe\BypassNRO.cmd``. This will allow us to continue without an internet connection as demonstrated in the video examples below. This does not apply while installing Windows with USB
+
 - See [media/oobe-windows7-example.mp4](https://raw.githubusercontent.com/amitxv/PC-Tuning/main/media/oobe-windows7-example.mp4)
 
 - See [media/oobe-windows8-example.mp4](https://raw.githubusercontent.com/amitxv/PC-Tuning/main/media/oobe-windows8-example.mp4)

--- a/docs/pre-install.md
+++ b/docs/pre-install.md
@@ -62,15 +62,6 @@ For the next steps, you are required to disconnect the Ethernet cable and not be
 
 - When installing Windows 8 with a USB, you may be required to enter a key. Use the generic key ``GCRJD-8NW9H-F2CDX-CCM8D-9D6T9`` to bypass this step (this does not activate Windows)
 
-- When installing Win11 with a USB, you may encounter system requirement issues. To bypass the checks, press ``Shift+F10`` to open CMD then type ``regedit`` and add the relevant registry keys listed below
-
-    ```
-    [HKEY_LOCAL_MACHINE\SYSTEM\Setup\LabConfig]
-    "BypassTPMCheck"=dword:00000001
-    "BypassRAMCheck"=dword:00000001
-    "BypassSecureBootCheck"=dword:00000001
-    ```
-
 ### Install using DISM Apply-Image (without a USB storage device)
 
 - Create a new partition by [shrinking a volume](https://docs.microsoft.com/en-us/windows-server/storage/disk-management/shrink-a-basic-volume) and assign the newly created unallocated space a drive letter


### PR DESCRIPTION
Windows 11 by default does not allow to be installed on low-end/not acceptable by the requirements devices, thus users may encounter a lot of issues.

Another possible issue is that user may see a problem while running the installer without the internet connection, it was needed to open CMD and execute ``oobe\BypassNRO.cmd`` in order to fix the issue.

However, in December 2020, Ventoy created two plugins that fix those issues. Since then, application automatically enables the required fixes, so that you are not required to make any changes.

![image](https://github.com/amitxv/PC-Tuning/assets/101590573/48c8fb42-77c7-4b16-b2bc-6383065db6fd)
![image](https://github.com/amitxv/PC-Tuning/assets/101590573/77b10cf4-091e-4591-9a49-fb2172257e4a)

**NOTE**: Changes obviously applies only when you are installing Windows with USB, you are only needed to use  ``oobe\BypassNRO.cmd`` while using DISM.