### PR TITLE
Clarify a section in pre-install

### DIFF
--- a/docs/pre-install.md
+++ b/docs/pre-install.md
@@ -66,7 +66,7 @@ Configure a [dual-boot](https://en.wikipedia.org/wiki/Multi-booting) to separate
 
     - See the [Configuring Applications](/docs/post-install.md#configuring-applications) section for more information
 
-- The behavior of processes that are affected by a single process raising the clock interrupt frequency significantly changed in Windows 10 2004+, and was [further developed in Windows 11](/media/windows11-timeapi-changes.png), to increase power efficiency but consequently breaks real-time applications and causes incredibly imprecise timing across the operating system. However, the old implementation can be restored in server 2022+ and Windows 11+ [with a registry entry](/docs/research.md#fixing-timing-precision-in-windows-after-the-great-rule-change). For this reason, it would be appropriate to avoid builds released after Windows 10 2004 which aren't Windows 11+ or Server 2022+
+- The behavior of processes that are affected by a single process raising the clock interrupt frequency significantly changed in Windows 10 2004+, and was [further developed in Windows 11](/media/windows11-timeapi-changes.png), to increase power efficiency but consequently breaks real-time applications and causes incredibly imprecise timing across the operating system. However, the old implementation can be restored in server 2022+ and Windows 11+ [with a registry entry](/docs/research.md#fixing-timing-precision-in-windows-after-the-great-rule-change). For this reason, it would be appropriate to avoid builds starting from Windows 10 2004 which aren't Windows 11+ or Server 2022+
 
 - As of May 2023, Windows 11 limits the message rate of background raw input listeners
 


### PR DESCRIPTION
A user had mentioned that the text here contains confusing languages regarding the Timer Resolution behavior of Windows 10 2004. I've proposed a change to clarify things.